### PR TITLE
chore: Update the build GHA workflow so it stops complaining about deprecated modules.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,39 +15,15 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-
-      - name: Checkout code
-        id: checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-          submodules: true
-
-      - name: Tag Info
-        id: tag_info
-        run: |
-          export IMAGE_TAG="${GITHUB_REF#refs/*/}"
-          export IMAGE_TAG=${IMAGE_TAG//[^[:alnum:].-]/-}
-          echo ::set-output name=IMAGE_TAG::${IMAGE_TAG}
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.ECR_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.ECR_AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
-
-      - name: Login to Public ECR
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
-        with:
-          registry: public.ecr.aws
-          username: ${{ secrets.ECR_AWS_ACCESS_KEY_ID }}
-          password: ${{ secrets.ECR_AWS_SECRET_ACCESS_KEY }}
-        env:
-          AWS_REGION: us-east-1
-
-      - name: Build, tag, and push image to Amazon ECR
-        uses: docker/build-push-action@v2
-        with:
-          push: true
-          tags: public.ecr.aws/unocha/hdx-n8n:${{ steps.tag_info.outputs.IMAGE_TAG }}
+    - name: Build
+      id: build-action
+      uses: UN-OCHA/actions/drupal-docker-build@main
+      with:
+        aws_access_key_id: ${{ secrets.ECR_AWS_ACCESS_KEY_ID }}
+        aws_secret_access_key: ${{ secrets.ECR_AWS_ACCESS_KEY_ID }}
+        docker_registry_url: public.ecr.aws
+        docker_registry_path: /unocha/
+        docker_image: hdx-n8n
+        docker_username: ${{ secrets.ECR_AWS_ACCESS_KEY_ID }}
+        docker_password: ${{ secrets.ECR_AWS_SECRET_ACCESS_KEY }}
+        ecr_github_token: ${{ secrets.ECR_GITHUB_TOKEN }}


### PR DESCRIPTION
There is no reason in principle it cannot use the same workflow as other docker builds, so why not try. Much easier.